### PR TITLE
Update README link to ppxlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Standard Jane Street ppx rewriters
 ==================================
 
-ppx\_jane is a [ppx_driver](https://github.com/janestreet/ppx_driver)
-including all standard ppx rewriters.
+ppx\_jane is a [ppxlib](https://github.com/ocaml-ppx/ppxlib)-based
+driver bundling Jane Street's standard ppx rewriters.
 
 Using ppx\_jane in the toplevel
 -------------------------------


### PR DESCRIPTION
## Summary
- replace the deprecated `ppx_driver` README link with the maintained `ppxlib` successor
- describe `ppx_jane` as the driver bundling Jane Street's standard rewriters

## Why
The existing link redirects readers to an archived ecosystem predecessor, which is confusing for new users trying to understand the current PPX stack.

## Validation
- `git diff --check`
- confirmed `ocaml-ppx/ppxlib` is active and not archived
- confirmed no `ppx_driver` references remain in `README.md`

Fixes #8